### PR TITLE
Issue#14 Added libstdc++ to docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,8 @@ FROM alpine
 
 # Install some libs
 RUN apk add --no-cache openssl && \
-    apk add --no-cache ncurses-libs
+    apk add --no-cache ncurses-libs && \
+    apk add --no-cache libstdc++
 
 # Install the released application
 COPY --from=0 /buildroot/dockerwatch/_build/prod/rel/dockerwatch /dockerwatch


### PR DESCRIPTION
Added stdc lib to apk in docker file

`
RUN apk add --no-cache openssl && \
    apk add --no-cache ncurses-libs && \
    apk add --no-cache libstdc++
`

Image will run now.