### PR TITLE
pin OTP version and upgrade cowboy to avoid SSL_ERROR_SYSCALL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage 0
-FROM erlang:alpine
+FROM erlang:24-alpine
 
 # Set working directory
 RUN mkdir /buildroot

--- a/dockerwatch/rebar.config
+++ b/dockerwatch/rebar.config
@@ -1,6 +1,6 @@
 
 {deps, [{jsone,  "1.4.7"},   %% JSON Encode/Decode
-        {cowboy, "2.5.0"}]}. %% HTTP Server
+        {cowboy, "2.9.0"}]}. %% HTTP Server
 
 {relx, [{release, {dockerwatch, "1.0.0"}, [dockerwatch]},
         {vm_args, "config/vm.args"},


### PR DESCRIPTION
Seems that OTP current version 24 and cowboy 2.5.0 have incompatibility because of a deprecated method

  _build/default/lib/ranch/src/ranch_ssl.erl:141:7: Warning: ssl:ssl_accept/3 is removed; use ssl_handshake/1,2,3 instead

This results in the POST method being rejected as follows

   curl --cacert ssl/dockerwatch-ca.pem -i -H "Content-Type: application/json" -X POST -d "" https://localhost:8443/cnt
curl: (35) OpenSSL SSL_connect: SSL_ERROR_SYSCALL in connection to localhost:8443

The Dockerfile was not pinning the Erlang version, but picking 'FROM erlang:alpine' which is effectively 'latest'. However in the rebar3.config file the cowboy version was pinned at 2.5.0

Either reverting OTP to 23 (or below) or upgrading cowboy to 2.9.0 fixed the problem and all the steps in the readme completed as expected.

This pull request updates the cowboy version to 2.9.0 (current) and explicitly pins the OTP to avoid anyone else hitting this problem